### PR TITLE
Add vagrant configuration for Linux VM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ example/native-client/plugins/
 exercises/ch-7-ex-0/platforms/
 exercises/ch-7-ex-0/plugins/
 .DS_Store
+.vagrant

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ This environment is built on CentOS7 image.
 To run environment type:  
 `vagrant up`
 
+To enable automatic source code folder synchronisation run:  
+`vagrant rsync-auto`
+
 After this you can connect to environment:  
 `vagrant ssh`  
 And run first exercise:

--- a/README.md
+++ b/README.md
@@ -13,3 +13,30 @@ OAuth 2 in Action teaches you practical use and deployment of this protocol from
 ## About the authors
 
 Justin Richer is a systems architect, software engineer, standards editor, and service designer working as an independent consultant. [Antonio Sanso](http://blog.intothesymmetry.com/) works as Security Software Engineer, he is a vulnerability security researcher and an active open source contributor.
+
+## Runtime environment
+You can use virtual machine provisioned by Vagrant in order to work with examples attached to this book.
+
+Environment is setup using Vagrant and VirtualBox applications. So, please be sure that you have both applications installed:
+  - [VirtualBox](https://www.virtualbox.org/wiki/Downloads)  
+  - [Vagrant](https://www.vagrantup.com/downloads.html)
+
+This environment is built on CentOS7 image.  
+To run environment type:  
+`vagrant up`
+
+After this you can connect to environment:  
+`vagrant ssh`  
+And run first exercise:
+```
+cd /vagrant/exercises/ap-A-ex-0
+npm install
+node client.js
+node protectedResource.js
+node authorizationServer.js
+```
+
+After this you should be able to connect to services from host machine:
+  - localhost:9000
+  - localhost:9001
+  - localhost:9002

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,84 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "centos/7"
+  #config.vm.box_version = "1901.01"
+  config.vm.provision :shell, :path => "bootstrap.sh", privileged: false
+
+  config.vm.provider :virtualbox do |vb|
+    vb.name = "VagrantBox_CentOS7_OAuthInAction"
+    vb.memory = "8192"
+    vb.cpus = "2"
+  end
+
+  config.vm.network "forwarded_port", guest: 22, host: 2222, id: "ssh"
+  config.vm.network "forwarded_port", guest: 8080, host: 8080, id: "www"
+  config.vm.network "forwarded_port", guest: 9000, host: 9000, id: "cli"
+  config.vm.network "forwarded_port", guest: 9001, host: 9001, id: "srv"
+  config.vm.network "forwarded_port", guest: 9002, host: 9002, id: "res"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure("2") do |config|
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
   config.vm.box = "centos/7"
-  #config.vm.box_version = "1901.01"
+  #config.vm.box_version = "1902.01"
   config.vm.provision :shell, :path => "bootstrap.sh", privileged: false
 
   config.vm.provider :virtualbox do |vb|
@@ -21,6 +21,9 @@ Vagrant.configure("2") do |config|
     vb.memory = "8192"
     vb.cpus = "2"
   end
+
+  # force Vagrant to use rsync
+  config.vm.synced_folder ".", "/vagrant", type: "rsync"
 
   config.vm.network "forwarded_port", guest: 22, host: 2222, id: "ssh"
   config.vm.network "forwarded_port", guest: 8080, host: 8080, id: "www"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/bash
+
+# Install system updates
+echo "*******************************************"
+echo "Installing system updates ..."
+echo "*******************************************"
+sudo yum -y update
+sudo yum -y install java git net-tools lynx
+
+echo "*******************************************"
+echo "Installing node.js ..."
+echo "*******************************************"
+curl -sL https://rpm.nodesource.com/setup_10.x | sudo bash -
+sudo yum -y install nodejs

--- a/exercises/ap-A-ex-0/authorizationServer.js
+++ b/exercises/ap-A-ex-0/authorizationServer.js
@@ -40,10 +40,9 @@ app.get('/', function(req, res) {
 
 app.use('/', express.static('files/authorizationServer'));
 
-var server = app.listen(9001, 'localhost', function () {
+var server = app.listen(9001, '0.0.0.0', function () {
   var host = server.address().address;
   var port = server.address().port;
 
   console.log('OAuth Authorization Server is listening at http://%s:%s', host, port);
 });
- 

--- a/exercises/ap-A-ex-0/client.js
+++ b/exercises/ap-A-ex-0/client.js
@@ -17,9 +17,8 @@ app.get('/', function (req, res) {
 
 app.use('/', express.static('files/client'));
 
-var server = app.listen(9000, 'localhost', function () {
+var server = app.listen(9000, '0.0.0.0', function () {
   var host = server.address().address;
   var port = server.address().port;
   console.log('OAuth Client is listening at http://%s:%s', host, port);
 });
- 

--- a/exercises/ap-A-ex-0/protectedResource.js
+++ b/exercises/ap-A-ex-0/protectedResource.js
@@ -21,10 +21,9 @@ var resource = {
 	"description": "This data has been protected by OAuth 2.0"
 };
 
-var server = app.listen(9002, 'localhost', function () {
+var server = app.listen(9002, '0.0.0.0', function () {
   var host = server.address().address;
   var port = server.address().port;
 
   console.log('OAuth Resource Server is listening at http://%s:%s', host, port);
 });
- 

--- a/pull_box.sh
+++ b/pull_box.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/bash
+
+vagrant box update --box centos/7


### PR DESCRIPTION
Thanks to vagrant it is possible to create and run
preconfigured CentOS in VM, instead of using Windows.
Extend README with Vagrant description

Vagrant box is using rsync to synchronise source folder.
Shared folders from VirtualBox are hard to use,
since npm needs file links, which are not supported on Windows.

Apart from this the hostname has been changed from localhost
to 0.0.0.0, in order to be able to access servers from host machine.